### PR TITLE
Add Windows Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ editing of user keystrokes
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://github.com/rancher/rancher)
 - [VirtualBox](https://www.virtualbox.org/) - free and open-source hypervisor                    
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://www.virtualbox.org/wiki/Contributor_information)
+- [Windows Terminal](https://apps.microsoft.com/store/detail/windows-terminal/9N0DX20HK701?hl=de-de&gl=DE) - tabstyle windows command line/shell tool. Works with Subsystem/WSL and more. Custom look through integrated .json file                   
+[![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://github.com/microsoft/terminal/blob/main/CONTRIBUTING.md)
 
 ### Email
 


### PR DESCRIPTION
- add new Developer Tool "Windows Terminal"
- add link to official website for Windows Terminal
- add short description for Windows Terminal
- add contribute link + shieldimage to "https://github.com/microsoft/terminal/blob/main/CONTRIBUTING.md"