### PR TITLE
fix: correct Revert URL to point to GitHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ editing of user keystrokes<br/>
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://github.com/microsoft/terminal/blob/main/CONTRIBUTING.md)
 - [Yaade](https://docs.yaade.io/) - Yaade is an open-source, self-hosted, collaborative API development environment<br/>
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://github.com/EsperoTech/yaade)
-- [Revert](https://revert.dev/) - An open source unified API to build B2B product integrations<br/>
+- [Revert](https://github.com/revertinc/revert) - An open source unified API to build B2B product integrations<br/>
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://github.com/revertinc/revert)
 - [Panora](https://panora.dev) - Alternative to Merge.dev - Add an integration catalog to your SaaS in minutes, not months                     
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://github.com/panoratech/Panora/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
## Summary

The **Revert** entry linked to its product website (https://revert.dev/) instead of the actual open source repository. This PR fixes it to point to https://github.com/revertinc/revert — which is already where the contribute badge on the next line points.

## Changes

- **README.md** — changed `[Revert](https://revert.dev/)` → `[Revert](https://github.com/revertinc/revert)`

Closes #88