### PR TITLE
Add Tablesmit to Documents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ You don't have to be a developer to contribute to your favorite open source proj
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://www.scribus.net/contribute/)
 - [Sumatra PDF](https://www.sumatrapdfreader.org/free-pdf-reader.html) - free and open-source document viewer<br/>
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://www.sumatrapdfreader.org/free-pdf-reader.html)
+- [Tablesmit](https://tablesmit.com) - a minimalist table builder for analytical writing with support for headers, formatting, merge cells, and export to PDF, Excel, CSV, and LaTeX<br/>
+[![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://github.com/Olayiwola72/tablesmit) [![Donate](https://cdn.rawgit.com/sereneblue/awesome-oss/master/donate.svg)](https://github.com/sponsors/Olayiwola72/)
 
 ### Developer Tools
 


### PR DESCRIPTION
## Adding Tablesmit to awesome-oss

**Project:** Tablesmit
**Repo:** https://github.com/Olayiwola72/tablesmit
**Live URL:** https://tablesmit.com

**What it does:**
Tablesmit is a minimalist, open source table builder for analytical writing. It lets writers, analysts, and researchers build clean structured tables with full control over headers, column formatting, merge cells, and export to PDF, Excel, CSV, and LaTeX — all in the browser, no signup required.

**Why it fits:**
- MIT licensed, fully open source
- Fits in the Documents category alongside other document creation tools
- Has both contribute (GitHub repo) and donate (GitHub Sponsors) links

**Category:** Documents