### PR TITLE
Add Markstream to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ You don't have to be a developer to contribute to your favorite open source proj
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://github.com/Hook0/hook0/blob/master/contributing.md)
 - [Manifest](https://manifest.build/) - Open-source Backend-as-a-Service that enables developers to create backends effortlessly.<br/>
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://github.com/mnfst/manifest/discussions/categories/feature-request)
+- [Markstream](https://markstream.simonhe.me/) - multi-framework streaming Markdown renderer for AI chat interfaces<br/>
+[![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://github.com/Simon-He95/markstream-vue/blob/main/CONTRIBUTING.md)
 - [Mosh](https://mosh.org/) - remote terminal application that allows roaming, supports intermittent connectivity, and provides intelligent local echo and line 
 editing of user keystrokes<br/>
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://mosh.org/#faq)


### PR DESCRIPTION
Adds [Markstream](https://github.com/Simon-He95/markstream-vue) to **Developer Tools**, following the list template and linking its contribution guide.

Markstream is an MIT-licensed, multi-framework streaming Markdown renderer for AI chat interfaces. It supports Vue/Nuxt, React/Next.js, Svelte, Angular, and Vue 2, with Mermaid, KaTeX, syntax highlighting, safe HTML, and low-jitter incremental rendering.

It meets the contribution criteria:

- 2.7k+ GitHub stars
- Active development (latest commits in July 2026)
- Public source and contribution guide
- Project documentation: https://markstream.simonhe.me/

I searched the list and existing pull requests before submitting and found no Markstream entry. Thank you for maintaining the list!