### PR TITLE
Fix FreeCAD link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ editing of user keystrokes<br/>
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://www.blender.org/get-involved/) [![Donate](https://cdn.rawgit.com/sereneblue/awesome-oss/master/donate.svg)](https://www.blender.org/foundation/donation-payment/)
 - [Caesium Image Compressor](https://saerasoft.com/caesium/) - advanced compression tool for photos and images (JPG, PNG, GIF)<br/>
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://github.com/Lymphatus/caesium-image-compressor) [![Donate](https://cdn.rawgit.com/sereneblue/awesome-oss/master/donate.svg)](https://saerasoft.com/caesium/)
-- [FreeCAD](https://www.freecadweb.org/) -  general purpose parametric 3D CAD modeler<br/>
+- [FreeCAD](https://www.freecad.org/) -  general purpose parametric 3D CAD modeler<br/>
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://wiki.freecad.org/Help_FreeCAD) [![Donate](https://cdn.rawgit.com/sereneblue/awesome-oss/master/donate.svg)](https://wiki.freecad.org/Donate)
 - [GIMP](https://www.gimp.org/) - raster graphics editor used for image retouching and editing, free-form drawing, converting between different image formats, and more specialized tasks<br/>
 [![Contribute](https://cdn.rawgit.com/sereneblue/awesome-oss/master/contribute.svg)](https://www.gimp.org/develop/) [![Donate](https://cdn.rawgit.com/sereneblue/awesome-oss/master/donate.svg)](https://www.gimp.org/donating/)


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file, correcting the URL for the FreeCAD project to its current official website.

- Changed the FreeCAD link from `freecadweb.org` to `freecad.org` to ensure users are directed to the correct official site.